### PR TITLE
Move comma-dangle rule to the shareable Auth0 config eslint package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2244,7 +2244,7 @@ Other Style Guides
   - Code Style Linters
     + [ESlint](http://eslint.org/) - [Auth0 Style .eslintrc](https://github.com/auth0/javascript/blob/master/linters/.eslintrc)
     + [JSHint](http://jshint.com/) - [Auth0 Style .jshintrc](https://github.com/auth0/javascript/blob/master/linters/.jshintrc)
-    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
+    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Auth0 Style .jscsrc](https://github.com/auth0/javascript/blob/master/linters/.jscsrc)
 
 **Other Style Guides**
 

--- a/es5/README.md
+++ b/es5/README.md
@@ -1561,7 +1561,7 @@
 
   - Code Style Linters
     + [JSHint](http://www.jshint.com/) - [Auth0 Style .jshintrc](https://github.com/auth0/javascript/blob/master/linters/jshintrc)
-    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
+    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Auth0 Style .jscsrc](https://github.com/auth0/javascript/blob/master/linters/.jscsrc)
 
 **Other Style Guides**
 

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -1,5 +1,4 @@
 // Copy this file, and add rule overrides as needed.
 {
-  "extends": "airbnb",
-  "comma-dangle", [2, "never"]
+  "extends": "auth0"
 }

--- a/packages/eslint-config-auth0/rules/errors.js
+++ b/packages/eslint-config-auth0/rules/errors.js
@@ -1,7 +1,7 @@
 module.exports = {
   'rules': {
     // disallow trailing commas in object literals
-    'comma-dangle': [2, 'always-multiline'],
+    'comma-dangle': [2, 'never'],
     // disallow assignment in conditional expressions
     'no-cond-assign': [2, 'always'],
     // disallow use of console


### PR DESCRIPTION
Move comma-dangle rule to the shareable Auth0 config eslint package and update links to .jscsrc file
