### PR TITLE
Allow early use of functions

### DIFF
--- a/packages/eslint-config-auth0/rules/variables.js
+++ b/packages/eslint-config-auth0/rules/variables.js
@@ -21,6 +21,6 @@ module.exports = {
     // disallow declaration of variables that are not used in the code
     'no-unused-vars': [2, { 'vars': 'local', 'args': 'after-used' }],
     // disallow use of variables before they are defined
-    'no-use-before-define': 2
+    'no-use-before-define': [1, 'nofunc']
   }
 };


### PR DESCRIPTION
eslint `no-use-before-define`: http://eslint.org/docs/rules/no-use-before-define
