### PR TITLE
Removed redundant peer dependencies

### DIFF
--- a/packages/eslint-config-auth0/package.json
+++ b/packages/eslint-config-auth0/package.json
@@ -49,10 +49,5 @@
     "react": "^0.14.8",
     "tape": "^4.5.1",
     "parallelshell": "^2.0.0"
-  },
-  "peerDependencies": {
-    "eslint": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
-    "eslint-plugin-react": "^4.3.0"
   }
 }


### PR DESCRIPTION
To prevent warnings in npm installs
