### PR TITLE
Add `_id` exception to `no-underscore-dangle` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2787,7 +2787,7 @@ Other Style Guides
     ```
 
   <a name="naming--leading-underscore"></a><a name="22.4"></a>
-  - [23.4](#naming--leading-underscore) Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
+  - [23.4](#naming--leading-underscore) Do not use trailing or leading underscores, with the exception of `_id` because it's common on projects that use mongo. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
 
     > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present.
 

--- a/packages/eslint-config-auth0-base/index.js
+++ b/packages/eslint-config-auth0-base/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base',
     './rules/errors',
+    './rules/style',
     './rules/variables'
   ].map(require.resolve),
   parserOptions: {

--- a/packages/eslint-config-auth0-base/legacy.js
+++ b/packages/eslint-config-auth0-base/legacy.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base/legacy',
     './rules/errors',
+    './rules/style',
     './rules/variables'
   ].map(require.resolve),
   env: {

--- a/packages/eslint-config-auth0-base/rules/style.js
+++ b/packages/eslint-config-auth0-base/rules/style.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    // disallow dangling underscores in identifiers, but allow `_id`.
+    'no-underscore-dangle': ['error', { allow: ['_id'] }]
+  }
+};


### PR DESCRIPTION
Based on feedback, some changes:
- `no-param-reassign` because the param object mutation it's a common pattern across express middlewares.
- `no-underscore-dangle` disallow `_id` identifier, primary key on MongoDB documents.

**Breaking change.**

## TODO:

- [ ] README.md: documentation updates.